### PR TITLE
controlador FamiliasProfesionalesController por coincidencia ID

### DIFF
--- a/app/Http/Controllers/FamiliasProfesionalesController.php
+++ b/app/Http/Controllers/FamiliasProfesionalesController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 class FamiliasProfesionalesController extends Controller
 {
    
-    public $familias_profesionales = array(
+    public static $familias_profesionales = array(
         array('codigo' => 'ADG','nombre' => 'ACTIVIDADES FÍSICAS Y DEPORTIVAS'),
         array('codigo' => 'AFD','nombre' => 'ADMINISTRACIÓN Y GESTIÓN'),
         array('codigo' => 'AGA','nombre' => 'AGRARIA'),
@@ -39,14 +39,14 @@ class FamiliasProfesionalesController extends Controller
     public function getIndex()
     {
         return view('familiasProfesionales.index', [
-            'familias' => $this->familias_profesionales
+            'familias' => self::$familias_profesionales
         ]);
     }
 
     public function getShow($id)
     {
         return view('familiasProfesionales.show')
-            ->with('familia', $this->familias_profesionales[$id])
+            ->with('familia', self::$familias_profesionales[$id])
             ->with('id', $id);
     }
 
@@ -58,7 +58,7 @@ class FamiliasProfesionalesController extends Controller
     public function getEdit($id)
     {
         return view('familiasProfesionales.edit')
-            ->with('familia', $this->familias_profesionales[$id])
+            ->with('familia', self::$familias_profesionales[$id])
             ->with('id', $id);
     }
 };


### PR DESCRIPTION
Creado el controlador "FamiliasProfesionalesController" he cambiado el atributo del array asociativo familias profesionales de static a una propiedad normal de la clase, además el parámetro de búsqueda en el get es por $id (index), no por el valor de la clave codigo.